### PR TITLE
enable CuDNN's autotuner flag in PyTorch

### DIFF
--- a/PyTorch_CIFAR.ipynb
+++ b/PyTorch_CIFAR.ipynb
@@ -22,6 +22,7 @@
     "import torch\n",
     "import torch.nn as nn\n",
     "import torch.nn.functional as F\n",
+    "torch.backends.cudnn.benchmark=True # enables cudnn's auto-tuner\n",
     "import torch.optim as optim\n",
     "import torch.utils.data as data_utils\n",
     "from torchvision import datasets, transforms\n",


### PR DESCRIPTION
> The notebooks are not specifically written for speed, instead they aim to create an easy comparison between the frameworks. However, any suggestions on improving the training-time are welcome

As you are welcoming suggestions, here's a quick one. CuDNN by default keeps all of its autotuning capabilities behind an explicit codepath. By default we dont enable this code path in PyTorch. If enabled, and you have constant input sizes, this gives big benefits. However, if your input image sizes given to the network are constantly changing (for example, in training object detection networks), then the CuDNN autotuner will have a heavy penalty.

Because a simple CIFAR network has constant input size, this flag can be enabled and gives a big benefit.

It's not an obscure flag that we only recommend for micro-benchmarks, we showcase using this flag in all of our official [examples](https://github.com/pytorch/examples/) (where applicable)