### PR TITLE
Enable test mode during prediction

### DIFF
--- a/Caffe2_CIFAR.ipynb
+++ b/Caffe2_CIFAR.ipynb
@@ -264,7 +264,14 @@
    "source": [
     "%%time\n",
     "# Init test model\n",
-    "test_model= model_helper.ModelHelper(name=\"test_net\", init_params=False)\n",
+    "test_arg_scope = {\n",
+    "    'order': 'NCHW',\n",
+    "    'use_cudnn': True,\n",
+    "    'cudnn_exhaustive_search': True,\n",
+    "    'ws_nbytes_limit': (64 * 1024 * 1024),\n",
+    "    'is_test': True,\n",
+    "}\n",
+    "test_model= model_helper.ModelHelper(name=\"test_net\", init_params=False, arg_scope=test_arg_scope)\n",
     "create_model(test_model, device_opts=device_opts)\n",
     "workspace.RunNetOnce(test_model.param_init_net)\n",
     "workspace.CreateNet(test_model.net, overwrite=True)\n",
@@ -295,7 +302,7 @@
     }
    ],
    "source": [
-    "print(\"Accuracy: \", sum(y_guess == y_truth)/len(y_guess))"
+    "print(\"Accuracy: \", sum(y_guess == y_truth)/float(len(y_guess)))"
    ]
   }
  ],

--- a/Caffe2_CIFAR.ipynb
+++ b/Caffe2_CIFAR.ipynb
@@ -73,7 +73,7 @@
    "source": [
     "def create_model(m, device_opts) :\n",
     "    with core.DeviceScope(device_opts):\n",
-    "        conv1 = brew.conv(m, 'data', 'conv1', dim_in=3, dim_out=50, kernel=3, pad=1)\n",
+    "        conv1 = brew.conv(m, 'data', 'conv1', dim_in=3, dim_out=50, kernel=3, pad=1, no_gradient_to_input=1)\n",
     "        relu1 = brew.relu(m, conv1, 'relu1')\n",
     "        conv2 = brew.conv(m, relu1, 'conv2', dim_in=50, dim_out=50, kernel=3, pad=1)\n",
     "        pool1 = brew.max_pool(m, conv2, 'pool1', kernel=2, stride=2)\n",


### PR DESCRIPTION
This is similar to @bwasti 's pull request #7 : during testing, Caffe/Caffe2 passes an "is_test" option to remove the dropout effect. This can be achieved by passing the arg scope to the model constructor.

With this I am recording a 79% accuracy, which makes me wonder if there is a minor discrepancy in the underlying training code - I was expecting 78%, but it might be due to randomness.