### PR TITLE
Turn off type checking and use larger workspace for Chainer benchmark

### DIFF
--- a/Chainer_CIFAR.ipynb
+++ b/Chainer_CIFAR.ipynb
@@ -21,6 +21,8 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "os.environ['CHAINER_TYPE_CHECK'] = '0'\n",
+    "\n",
     "import sys\n",
     "import numpy as np\n",
     "import math\n",
@@ -37,6 +39,19 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "cuda.set_max_workspace_size(512 * 1024 * 1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
     "collapsed": false,
     "deletable": true,
     "editable": true
@@ -50,7 +65,9 @@
       "Python:  3.5.2 |Anaconda custom (64-bit)| (default, Jul  2 2016, 17:53:06) \n",
       "[GCC 4.4.7 20120313 (Red Hat 4.4.7-1)]\n",
       "Chainer:  2.0.2\n",
-      "Numpy:  1.13.1\n"
+      "CuPy:  1.0.2\n",
+      "Numpy:  1.13.1\n",
+      "GPU:  ['Tesla K80']\n"
      ]
     }
    ],
@@ -58,43 +75,9 @@
     "print(\"OS: \", sys.platform)\n",
     "print(\"Python: \", sys.version)\n",
     "print(\"Chainer: \", chainer.__version__)\n",
+    "print(\"CuPy: \", chainer.cuda.cupy.__version__)\n",
     "print(\"Numpy: \", np.__version__)\n",
     "print(\"GPU: \", get_gpu_name())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "class SymbolModule(chainer.Chain):\n",
-    "    def __init__(self):\n",
-    "        super(SymbolModule, self).__init__(\n",
-    "            conv1=L.Convolution2D(3, 50, ksize=(3,3), pad=(1,1)),\n",
-    "            conv2=L.Convolution2D(50, 50, ksize=(3,3), pad=(1,1)),      \n",
-    "            conv3=L.Convolution2D(50, 100, ksize=(3,3), pad=(1,1)),  \n",
-    "            conv4=L.Convolution2D(100, 100, ksize=(3,3), pad=(1,1)),  \n",
-    "            # feature map size is 8*8 by pooling\n",
-    "            fc1=L.Linear(100*8*8, 512),\n",
-    "            fc2=L.Linear(512, N_CLASSES),\n",
-    "        )\n",
-    "    \n",
-    "    def __call__(self, x):\n",
-    "        h = F.relu(self.conv2(F.relu(self.conv1(x))))\n",
-    "        h = F.max_pooling_2d(h, ksize=(2,2), stride=(2,2))\n",
-    "        h = F.dropout(h, 0.25)\n",
-    "        \n",
-    "        h = F.relu(self.conv4(F.relu(self.conv3(h))))\n",
-    "        h = F.max_pooling_2d(h, ksize=(2,2), stride=(2,2))\n",
-    "        h = F.dropout(h, 0.25)       \n",
-    "        \n",
-    "        h = F.dropout(F.relu(self.fc1(h)), 0.5)\n",
-    "        return self.fc2(h)"
    ]
   },
   {
@@ -107,10 +90,29 @@
    },
    "outputs": [],
    "source": [
-    "def init_model(m):\n",
-    "    optimizer = optimizers.MomentumSGD(lr=LR, momentum=MOMENTUM)\n",
-    "    optimizer.setup(m)\n",
-    "    return optimizer"
+    "class SymbolModule(chainer.Chain):\n",
+    "    def __init__(self):\n",
+    "        super(SymbolModule, self).__init__()\n",
+    "        with self.init_scope():\n",
+    "            self.conv1 = L.Convolution2D(3, 50, ksize=3, pad=1)\n",
+    "            self.conv2 = L.Convolution2D(50, 50, ksize=3, pad=1)\n",
+    "            self.conv3 = L.Convolution2D(50, 100, ksize=3, pad=1)\n",
+    "            self.conv4 = L.Convolution2D(100, 100, ksize=3, pad=1)\n",
+    "            # feature map size is 8*8 by pooling\n",
+    "            self.fc1 = L.Linear(100*8*8, 512)\n",
+    "            self.fc2 = L.Linear(512, N_CLASSES)\n",
+    "    \n",
+    "    def __call__(self, x):\n",
+    "        h = F.relu(self.conv2(F.relu(self.conv1(x))))\n",
+    "        h = F.max_pooling_2d(h, ksize=2, stride=2)\n",
+    "        h = F.dropout(h, 0.25)\n",
+    "        \n",
+    "        h = F.relu(self.conv4(F.relu(self.conv3(h))))\n",
+    "        h = F.max_pooling_2d(h, ksize=2, stride=2)\n",
+    "        h = F.dropout(h, 0.25)       \n",
+    "        \n",
+    "        h = F.dropout(F.relu(self.fc1(h)), 0.5)\n",
+    "        return self.fc2(h)"
    ]
   },
   {
@@ -123,8 +125,10 @@
    },
    "outputs": [],
    "source": [
-    "def to_chainer(array, **kwargs):\n",
-    "    return chainer.Variable(cuda.to_gpu(array), **kwargs)"
+    "def init_model(m):\n",
+    "    optimizer = optimizers.MomentumSGD(lr=LR, momentum=MOMENTUM)\n",
+    "    optimizer.setup(m)\n",
+    "    return optimizer"
    ]
   },
   {
@@ -150,8 +154,8 @@
       "Done.\n",
       "(50000, 3, 32, 32) (10000, 3, 32, 32) (50000,) (10000,)\n",
       "float32 float32 int32 int32\n",
-      "CPU times: user 3.01 s, sys: 1.67 s, total: 4.68 s\n",
-      "Wall time: 20.9 s\n"
+      "CPU times: user 2.78 s, sys: 1.47 s, total: 4.26 s\n",
+      "Wall time: 24.4 s\n"
      ]
     }
    ],
@@ -177,8 +181,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 192 ms, sys: 176 ms, total: 368 ms\n",
-      "Wall time: 380 ms\n"
+      "CPU times: user 188 ms, sys: 324 ms, total: 512 ms\n",
+      "Wall time: 544 ms\n"
      ]
     }
    ],
@@ -205,7 +209,7 @@
      "output_type": "stream",
      "text": [
       "CPU times: user 0 ns, sys: 0 ns, total: 0 ns\n",
-      "Wall time: 105 µs\n"
+      "Wall time: 89.4 µs\n"
      ]
     }
    ],
@@ -237,8 +241,8 @@
       "7\n",
       "8\n",
       "9\n",
-      "CPU times: user 3min 34s, sys: 42.1 s, total: 4min 16s\n",
-      "Wall time: 4min 16s\n"
+      "CPU times: user 3min 25s, sys: 34.9 s, total: 4min\n",
+      "Wall time: 4min\n"
      ]
     }
    ],
@@ -247,7 +251,13 @@
     "for j in range(EPOCHS):\n",
     "    for data, target in yield_mb(x_train, y_train, BATCHSIZE, shuffle=True):\n",
     "        # Get samples\n",
-    "        optimizer.update(L.Classifier(sym), to_chainer(data), to_chainer(target))\n",
+    "        data = cuda.to_gpu(data)\n",
+    "        target = cuda.to_gpu(target)\n",
+    "        output = sym(data)\n",
+    "        loss = F.softmax_cross_entropy(output, target)\n",
+    "        sym.cleargrads()\n",
+    "        loss.backward()\n",
+    "        optimizer.update()\n",
     "    # Log\n",
     "    print(j)"
    ]
@@ -265,8 +275,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.49 s, sys: 220 ms, total: 1.71 s\n",
-      "Wall time: 1.71 s\n"
+      "CPU times: user 1.32 s, sys: 308 ms, total: 1.63 s\n",
+      "Wall time: 1.63 s\n"
      ]
     }
    ],
@@ -277,10 +287,10 @@
     "y_truth = y_test[:n_samples]\n",
     "c = 0\n",
     "\n",
-    "with chainer.using_config('train', False):\n",
+    "with chainer.using_config('train', False), chainer.using_config('enable_backprop', False):\n",
     "    for data, target in yield_mb(x_test, y_test, BATCHSIZE):\n",
     "        # Forwards\n",
-    "        pred = chainer.cuda.to_cpu(sym(to_chainer(data)).data.argmax(-1))\n",
+    "        pred = cuda.to_cpu(sym(cuda.to_gpu(data)).data.argmax(-1))\n",
     "        # Collect results\n",
     "        y_guess[c*BATCHSIZE:(c+1)*BATCHSIZE] = pred\n",
     "        c += 1"
@@ -299,7 +309,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy:  0.780048076923\n"
+      "Accuracy:  0.788762019231\n"
      ]
     }
    ],


### PR DESCRIPTION
Thank you for providing the informative experiments to compare many frameworks.
This PR adds some general ways to improve the performance of Chainer.
1) Turn of type checking 2) Increase the workspace

And I refactored the model code to follow the new style introduced after Chainer v2 because this notebook is using Chainer v2, and simplified the training loop code.

I ran this notebook on Azure Data Science VM with K80 GPU, but re-running this to ensure the result would be better for fairness.