### PR TITLE
Tensorflow init params changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Input for this model is the standard [CIFAR-10 dataset](http://www.cs.toronto.ed
 
 | DL Library                          | Test Accuracy (%) | Training Time (s) | Using CuDNN? |
 | ----------------------------------- | ----------------- | ----------------- | ------------ |
+| [Tensorflow](Tensorflow_RNN.ipynb)  | 85                | 28                | Yes          |
 | [CNTK](CNTK_RNN.ipynb)              | 86                | 29                | Yes          |
 | [MXNet](MXNet_RNN.ipynb)            | 86                | 29                | Yes          |
 | [Pytorch](PyTorch_RNN.ipynb)        | 85                | 32                | Yes          |
 | [Keras(TF)](Keras_TF_RNN.ipynb)     | 86                | 33                | Yes          |
-| [Tensorflow](Tensorflow_RNN.ipynb)  | 77 (...?)         | 28                | Yes          |
 | [Keras(CNTK)](Keras_CNTK_RNN.ipynb) | 86                | 206               | No Available |
 
 Input for this model is the standard [IMDB movie review dataset](http://ai.stanford.edu/~amaas/data/sentiment/) containing 25k training reviews and 25k test reviews, uniformly split across 2 classes (positive/negative). Reviews are already downloaded as a tensor of word indexes e.g. (If you like adult comedy cartoons, like South Park) is received as (1 2 3 4 5 6 3 7 8). Processing follows [Keras](https://github.com/fchollet/keras/blob/master/keras/datasets/imdb.py) approach where start-character is set as 1, out-of-vocab (vocab size of 30k is used) represented as 2 and thus word-index starts from 3. Zero-padded / truncated to fixed axis of 150 words per review.

--- a/Tensorflow_RNN.ipynb
+++ b/Tensorflow_RNN.ipynb
@@ -66,14 +66,12 @@
     "                                                   num_units=NUMHIDDEN, \n",
     "                                                   input_size=EMBEDSIZE)\n",
     "        params_size_t = cudnn_cell.params_size()\n",
-    "        params = tf.Variable(tf.random_uniform([params_size_t]), validate_shape=False)   \n",
+    "        params = tf.Variable(tf.random_uniform([params_size_t], -0.1, 0.1), validate_shape=False)   \n",
     "        input_h = tf.Variable(tf.zeros([1, BATCHSIZE, NUMHIDDEN]))\n",
-    "\n",
     "        outputs, states = cudnn_cell(input_data=word_list,\n",
     "                                     input_h=input_h,\n",
-    "                                     params=params,\n",
-    "                                     is_training=True)\n",
-    "    logits = tf.layers.dense(outputs[-1], 2, activation=None, name='output')\n",
+    "                                     params=params)\n",
+    "        logits = tf.layers.dense(outputs[-1], 2, activation=None, name='output')\n",
     "    return logits"
    ]
   },
@@ -112,8 +110,8 @@
       "Padding to length 150\n",
       "(25000, 150) (25000, 150) (25000,) (25000,)\n",
       "int32 int32 int32 int32\n",
-      "CPU times: user 5.98 s, sys: 304 ms, total: 6.29 s\n",
-      "Wall time: 7.4 s\n"
+      "CPU times: user 5.69 s, sys: 364 ms, total: 6.05 s\n",
+      "Wall time: 7.35 s\n"
      ]
     }
    ],
@@ -134,8 +132,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 764 ms, sys: 44 ms, total: 808 ms\n",
-      "Wall time: 810 ms\n"
+      "CPU times: user 736 ms, sys: 36 ms, total: 772 ms\n",
+      "Wall time: 773 ms\n"
      ]
     }
    ],
@@ -156,8 +154,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 672 ms, sys: 296 ms, total: 968 ms\n",
-      "Wall time: 968 ms\n"
+      "CPU times: user 624 ms, sys: 340 ms, total: 964 ms\n",
+      "Wall time: 966 ms\n"
      ]
     }
    ],
@@ -178,11 +176,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0 Train accuracy: 0.8125\n",
-      "1 Train accuracy: 0.8125\n",
-      "2 Train accuracy: 0.78125\n",
-      "CPU times: user 21.3 s, sys: 3.05 s, total: 24.4 s\n",
-      "Wall time: 28.1 s\n"
+      "0 Train accuracy: 0.859375\n",
+      "1 Train accuracy: 0.9375\n",
+      "2 Train accuracy: 0.96875\n",
+      "CPU times: user 21.3 s, sys: 2.96 s, total: 24.3 s\n",
+      "Wall time: 28.6 s\n"
      ]
     }
    ],
@@ -209,8 +207,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 10.1 s, sys: 2.22 s, total: 12.3 s\n",
-      "Wall time: 12 s\n"
+      "CPU times: user 10.2 s, sys: 2.18 s, total: 12.4 s\n",
+      "Wall time: 12.1 s\n"
      ]
     }
    ],
@@ -236,7 +234,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy:  0.770953525641\n"
+      "Accuracy:  0.845032051282\n"
      ]
     }
    ],


### PR DESCRIPTION
Following traveller59's "default range of tf.random_uniform is [0, 1],
it‘s still too large for RNN, [-0.1, 0.1] is recommended."