### PR TITLE
Knet notebooks added

### DIFF
--- a/Knet_CNN.ipynb
+++ b/Knet_CNN.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Knet CNN Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# After installing and starting Julia run the following to install the required packages:\n",
+    "# julia> Pkg.init(); for p in (\"IJulia\",\"Knet\"); Pkg.add(p); end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mChecking out Knet ilkarman...\n",
+      "\u001b[39m\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mPulling Knet latest ilkarman...\n",
+      "\u001b[39m\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mNo packages to install, update or remove\n",
+      "\u001b[39m\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mBuilding Knet\n",
+      "\u001b[39m\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mCompiling CUDA kernels.\n",
+      "\u001b[39m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "make: `libknet8.so' is up to date.\n"
+     ]
+    }
+   ],
+   "source": [
+    "Pkg.checkout(\"Knet\",\"ilkarman\") # make sure we have the right Knet version\n",
+    "Pkg.build(\"Knet\")\n",
+    "using Knet\n",
+    "True=true # so we can read the python params\n",
+    "include(\"common/params.py\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OS: Linux\n",
+      "Julia: 0.6.1\n",
+      "Knet: 0.8.5+\n",
+      "GPU: Tesla K80\n",
+      "Tesla K80\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "println(\"OS: \", Sys.KERNEL)\n",
+    "println(\"Julia: \", VERSION)\n",
+    "println(\"Knet: \", Pkg.installed(\"Knet\"))\n",
+    "println(\"GPU: \", readstring(`nvidia-smi --query-gpu=name --format=csv,noheader`))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# define model\n",
+    "function initmodel(; atype=KnetArray, dtype=Float32, winit=xavier, binit=zeros)\n",
+    "    w(dims...)=atype(winit(dtype,dims...))\n",
+    "    b(dims...)=atype(binit(dtype,dims...))\n",
+    "    return Any[\n",
+    "        w(3,3,3,50), b(1,1,50,1),\n",
+    "        w(3,3,50,50), b(1,1,50,1),\n",
+    "        w(3,3,50,100), b(1,1,100,1),\n",
+    "        w(3,3,100,100), b(1,1,100,1),\n",
+    "        w(512,6400), b(512,1),\n",
+    "        w(10,512), b(10,1)\n",
+    "    ]\n",
+    "end;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# define loss and its gradient\n",
+    "function predict(w,x)\n",
+    "    convbias(x,w,b) = conv4(w,x;padding=1) .+ b\n",
+    "    fc(x,w,b) = w * mat(x) .+ b;\n",
+    "    x = relu.(convbias(x,w[1],w[2]))\n",
+    "    x = relu.(pool(convbias(x,w[3],w[4])))\n",
+    "    x = dropout(x,0.25)\n",
+    "    x = relu.(convbias(x,w[5],w[6]))\n",
+    "    x = relu.(pool(convbias(x,w[7],w[8])))\n",
+    "    x = dropout(x,0.25)\n",
+    "    x = relu.(fc(x,w[9],w[10]))\n",
+    "    x = dropout(x,0.5)\n",
+    "    return fc(x,w[11],w[12])\n",
+    "end\n",
+    "\n",
+    "loss(w,x,y)=nll(predict(w,x),y) # nll: negative log likelihood\n",
+    "lossgradient = grad(loss);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0.119320 seconds (74.03 k allocations: 3.523 MiB)\n",
+      "32×32×3×50000 Array{Float32,4}\n",
+      "50000-element Array{UInt8,1}\n",
+      "32×32×3×10000 Array{Float32,4}\n",
+      "10000-element Array{UInt8,1}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# load data\n",
+    "include(Knet.dir(\"data\",\"cifar.jl\"))\n",
+    "@time (xtrn,ytrn,xtst,ytst,lbls)=cifar10()\n",
+    "for d in (xtrn,ytrn,xtst,ytst); println(summary(d)); end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# prepare for training\n",
+    "model = initmodel()\n",
+    "optim = optimizers(model, Momentum; lr=LR, gamma=MOMENTUM);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0.044195 seconds (12.18 k allocations: 647.599 KiB)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# force precompile\n",
+    "x1 = KnetArray(xtrn[:,:,:,1:BATCHSIZE])\n",
+    "y1 = ytrn[1:BATCHSIZE]\n",
+    "@time lossgradient(model,x1,y1);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mTraining...\n",
+      "\u001b[39m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 14.220216 seconds (1.89 M allocations: 670.091 MiB, 0.81% gc time)\n",
+      " 14.109362 seconds (1.90 M allocations: 670.130 MiB, 0.76% gc time)\n",
+      " 14.125811 seconds (1.90 M allocations: 670.130 MiB, 0.76% gc time)\n",
+      " 14.141050 seconds (1.90 M allocations: 670.130 MiB, 0.76% gc time)\n",
+      " 14.143818 seconds (1.90 M allocations: 670.200 MiB, 0.81% gc time)\n",
+      " 14.176805 seconds (1.90 M allocations: 670.130 MiB, 0.78% gc time)\n",
+      " 14.296330 seconds (1.90 M allocations: 670.132 MiB, 1.28% gc time)\n",
+      " 14.171749 seconds (1.90 M allocations: 670.130 MiB, 0.43% gc time)\n",
+      " 14.163746 seconds (1.90 M allocations: 670.130 MiB, 0.43% gc time)\n",
+      " 14.164013 seconds (1.90 M allocations: 670.130 MiB, 0.41% gc time)\n",
+      "141.718562 seconds (18.98 M allocations: 6.545 GiB, 0.72% gc time)\n"
+     ]
+    }
+   ],
+   "source": [
+    "info(\"Training...\")\n",
+    "@time for epoch in 1:EPOCHS\n",
+    "    @time for (x,y) in minibatch(xtrn,ytrn,BATCHSIZE;shuffle=true,xtype=KnetArray)\n",
+    "        grads = lossgradient(model, x, y)\n",
+    "        update!(model, grads, optim)\n",
+    "    end\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1.040271 seconds (104.82 k allocations: 122.664 MiB, 1.02% gc time)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0.7784455128205128"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# test accuracy\n",
+    "testdata = minibatch(xtst,ytst,BATCHSIZE;xtype=KnetArray)\n",
+    "@time accuracy(testdata,model,predict)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 0.6.1",
+   "language": "julia",
+   "name": "julia-0.6"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "0.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Knet_CNN.ipynb
+++ b/Knet_CNN.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "# After installing and starting Julia run the following to install the required packages:\n",
-    "# julia> Pkg.init(); for p in (\"IJulia\",\"Knet\"); Pkg.add(p); end"
+    "# julia> Pkg.init(); for p in (\"CUDAdrv\",\"IJulia\",\"Knet\"); Pkg.add(p); end"
    ]
   },
   {
@@ -201,17 +201,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 14.220216 seconds (1.89 M allocations: 670.091 MiB, 0.81% gc time)\n",
-      " 14.109362 seconds (1.90 M allocations: 670.130 MiB, 0.76% gc time)\n",
-      " 14.125811 seconds (1.90 M allocations: 670.130 MiB, 0.76% gc time)\n",
-      " 14.141050 seconds (1.90 M allocations: 670.130 MiB, 0.76% gc time)\n",
-      " 14.143818 seconds (1.90 M allocations: 670.200 MiB, 0.81% gc time)\n",
-      " 14.176805 seconds (1.90 M allocations: 670.130 MiB, 0.78% gc time)\n",
-      " 14.296330 seconds (1.90 M allocations: 670.132 MiB, 1.28% gc time)\n",
-      " 14.171749 seconds (1.90 M allocations: 670.130 MiB, 0.43% gc time)\n",
-      " 14.163746 seconds (1.90 M allocations: 670.130 MiB, 0.43% gc time)\n",
-      " 14.164013 seconds (1.90 M allocations: 670.130 MiB, 0.41% gc time)\n",
-      "141.718562 seconds (18.98 M allocations: 6.545 GiB, 0.72% gc time)\n"
+      " 15.503366 seconds (2.14 M allocations: 683.569 MiB, 0.62% gc time)\n",
+      " 14.629396 seconds (1.90 M allocations: 670.151 MiB, 0.55% gc time)\n",
+      " 14.634947 seconds (1.90 M allocations: 670.151 MiB, 0.56% gc time)\n",
+      " 14.585767 seconds (1.90 M allocations: 670.151 MiB, 0.55% gc time)\n",
+      " 14.674386 seconds (1.90 M allocations: 670.222 MiB, 0.59% gc time)\n",
+      " 14.705547 seconds (1.90 M allocations: 670.151 MiB, 0.57% gc time)\n",
+      " 14.740821 seconds (1.90 M allocations: 670.151 MiB, 0.54% gc time)\n",
+      " 14.775897 seconds (1.90 M allocations: 670.151 MiB, 0.53% gc time)\n",
+      " 14.911993 seconds (1.90 M allocations: 670.151 MiB, 0.60% gc time)\n",
+      " 14.818849 seconds (1.90 M allocations: 670.151 MiB, 0.58% gc time)\n",
+      "147.982460 seconds (19.22 M allocations: 6.558 GiB, 0.57% gc time)\n"
      ]
     }
    ],

--- a/Knet_RNN.ipynb
+++ b/Knet_RNN.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "# After installing and starting Julia run the following to install the required packages:\n",
-    "# julia> Pkg.init(); for p in (\"IJulia\",\"Knet\",\"PyCall\",\"JSON\",\"JLD2\"); Pkg.add(p); end"
+    "# julia> Pkg.init(); for p in (\"CUDAdrv\",\"IJulia\",\"Knet\",\"PyCall\",\"JLD2\"); Pkg.add(p); end"
    ]
   },
   {

--- a/Knet_RNN.ipynb
+++ b/Knet_RNN.ipynb
@@ -1,0 +1,262 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Knet RNN example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# After installing and starting Julia run the following to install the required packages:\n",
+    "# julia> Pkg.init(); for p in (\"IJulia\",\"Knet\",\"PyCall\",\"JSON\",\"JLD2\"); Pkg.add(p); end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mChecking out Knet ilkarman...\n",
+      "\u001b[39m\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mPulling Knet latest ilkarman...\n",
+      "\u001b[39m\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mNo packages to install, update or remove\n",
+      "\u001b[39m\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mBuilding Knet\n",
+      "\u001b[39m\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mCompiling CUDA kernels.\n",
+      "\u001b[39m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "make: `libknet8.so' is up to date.\n"
+     ]
+    }
+   ],
+   "source": [
+    "Pkg.checkout(\"Knet\",\"ilkarman\") # make sure we have the right Knet version\n",
+    "Pkg.build(\"Knet\")\n",
+    "using Knet\n",
+    "True=true # so we can read the python params\n",
+    "include(\"common/params_lstm.py\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OS: Linux\n",
+      "Julia: 0.6.1\n",
+      "Knet: 0.8.5+\n",
+      "GPU: Tesla K80\n",
+      "Tesla K80\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "println(\"OS: \", Sys.KERNEL)\n",
+    "println(\"Julia: \", VERSION)\n",
+    "println(\"Knet: \", Pkg.installed(\"Knet\"))\n",
+    "println(\"GPU: \", readstring(`nvidia-smi --query-gpu=name --format=csv,noheader`))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# define model\n",
+    "function initmodel()\n",
+    "    rnnSpec,rnnWeights = rnninit(EMBEDSIZE,NUMHIDDEN; rnnType=:gru)\n",
+    "    inputMatrix = KnetArray(xavier(Float32,EMBEDSIZE,MAXFEATURES))\n",
+    "    outputMatrix = KnetArray(xavier(Float32,2,NUMHIDDEN))\n",
+    "    return rnnSpec,(rnnWeights,inputMatrix,outputMatrix)\n",
+    "end;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define loss and its gradient\n",
+    "function predict(weights, inputs, rnnSpec)\n",
+    "    rnnWeights, inputMatrix, outputMatrix = weights # (1,1,W), (X,V), (2,H)\n",
+    "    indices = hcat(inputs...)' # (B,T)\n",
+    "    rnnInput = inputMatrix[:,indices] # (X,B,T)\n",
+    "    rnnOutput = rnnforw(rnnSpec, rnnWeights, rnnInput)[1] # (H,B,T)\n",
+    "    return outputMatrix * rnnOutput[:,:,end] # (2,H) * (H,B) = (2,B)\n",
+    "end\n",
+    "\n",
+    "loss(w,x,y,r)=nll(predict(w,x,r),y)\n",
+    "lossgradient = grad(loss);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  3.460234 seconds (11.93 M allocations: 569.737 MiB, 5.75% gc time)\n",
+      "25000-element Array{Array{Int32,1},1}\n",
+      "25000-element Array{Int8,1}\n",
+      "25000-element Array{Array{Int32,1},1}\n",
+      "25000-element Array{Int8,1}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# load data\n",
+    "include(Knet.dir(\"data\",\"imdb.jl\"))\n",
+    "@time (xtrn,ytrn,xtst,ytst,imdbdict)=imdb(maxlen=MAXLEN,maxval=MAXFEATURES)\n",
+    "for d in (xtrn,ytrn,xtst,ytst); println(summary(d)); end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# prepare for training\n",
+    "weights = nothing; knetgc(); # Reclaim memory from previous run\n",
+    "rnnSpec,weights = initmodel()\n",
+    "optim = optimizers(weights, Adam; lr=LR, beta1=BETA_1, beta2=BETA_2, eps=EPS);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0.055066 seconds (5.89 k allocations: 393.635 KiB)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# force precompile (optional)\n",
+    "(x,y) = first(minibatch(xtrn,ytrn,BATCHSIZE))\n",
+    "@time lossgradient(weights,x,y,rnnSpec);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mTraining...\n",
+      "\u001b[39m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  9.511471 seconds (365.05 k allocations: 44.876 MiB, 3.43% gc time)\n",
+      "  9.173121 seconds (367.03 k allocations: 44.604 MiB, 5.90% gc time)\n",
+      "  9.171262 seconds (367.76 k allocations: 44.615 MiB, 5.87% gc time)\n",
+      " 27.857207 seconds (1.11 M allocations: 134.422 MiB, 5.05% gc time)\n"
+     ]
+    }
+   ],
+   "source": [
+    "info(\"Training...\")\n",
+    "@time for epoch in 1:EPOCHS\n",
+    "    @time for (x,y) in minibatch(xtrn,ytrn,BATCHSIZE;shuffle=true)\n",
+    "        grads = lossgradient(weights,x,y,rnnSpec)\n",
+    "        update!(weights, grads, optim)\n",
+    "    end\n",
+    "end"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\u001b[1m\u001b[36mINFO: \u001b[39m\u001b[22m\u001b[36mTesting...\n",
+      "\u001b[39m"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2.778597 seconds (68.83 k allocations: 34.881 MiB, 7.74% gc time)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0.8534455128205128"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "info(\"Testing...\")\n",
+    "total = correct = 0\n",
+    "@time for (x,y) in minibatch(xtst,ytst,BATCHSIZE)\n",
+    "    total += accuracy(predict(weights,x,rnnSpec), y; average=false)\n",
+    "    correct += length(y)\n",
+    "end\n",
+    "total/correct"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Julia 0.6.1",
+   "language": "julia",
+   "name": "julia-0.6"
+  },
+  "language_info": {
+   "file_extension": ".jl",
+   "mimetype": "application/julia",
+   "name": "julia",
+   "version": "0.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Since we are essentially comparing a series of deterministic mathematical operat
 
 | DL Library                               | Test Accuracy (%) | Training Time (s) |
 | ---------------------------------------- | ----------------- | ----------------- |
-| [Knet](Knet_CNN.ipynb)                   | 78                | 142               |
+| [Knet](Knet_CNN.ipynb)                   | 78                | 148               |
 | [Caffe2](Caffe2_CNN.ipynb)               | 79                | 149               |
 | [MXNet](MXNet_CNN.ipynb)                 | 77                | 149               |
 | [Gluon](Gluon_CNN.ipynb)                 | 77                | 157               |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Since we are essentially comparing a series of deterministic mathematical operat
 
 | DL Library                               | Test Accuracy (%) | Training Time (s) |
 | ---------------------------------------- | ----------------- | ----------------- |
+| [Knet](Knet_CNN.ipynb)                   | 78                | 142               |
 | [Caffe2](Caffe2_CNN.ipynb)               | 79                | 149               |
 | [MXNet](MXNet_CNN.ipynb)                 | 77                | 149               |
 | [Gluon](Gluon_CNN.ipynb)                 | 77                | 157               |
@@ -43,6 +44,7 @@ Input for this model is the standard [CIFAR-10 dataset](http://www.cs.toronto.ed
 
 | DL Library                          | Test Accuracy (%) | Training Time (s) | Using CuDNN? |
 | ----------------------------------- | ----------------- | ----------------- | ------------ |
+| [Knet](Knet_RNN.ipynb)              | 85                | 28                | Yes          |
 | [Tensorflow](Tensorflow_RNN.ipynb)  | 85                | 28                | Yes          |
 | [CNTK](CNTK_RNN.ipynb)              | 86                | 29                | Yes          |
 | [MXNet](MXNet_RNN.ipynb)            | 86                | 29                | Yes          |


### PR DESCRIPTION
Dear Ilia, I am the author of [Knet](https://github.com/denizyuret/Knet.jl), the popular Julia deep learning package. You can find some info on Julia and Knet at:
* [Julia website](https://julialang.org/)
* [Knet documentation](https://denizyuret.github.io/Knet.jl/latest)
* [Video tutorial at JuliaCon-2017](http://www.denizyuret.com/2017/05/juliacon-2017-berkeley-june-20-24.html)
* [Paper at NIPS MLSys Workshop](http://www.denizyuret.com/2016/12/knet-beginning-deep-learning-with-100.html)

As many people in the Julia community are interested in performance and readability comparisons with Python and comparisons between ML systems in general, I thought I would contribute Julia/Knet implementations of your examples. I tried to mirror the examples as close as I could, running them on a K80 server with "Intel(R) Xeon(R) CPU E5-2695 v4 @ 2.10GHz" CPUs. If you want to run them on your setup, all you need to do is to install the latest version of Julia and add the packages given at the top of each notebook before you run. I recommend running them twice to isolate compilation costs. Thanks for your other examples which I will share with the Julia community.