### PR TITLE
Modifying the MXNet/Gluon and MXNet/Module API notebooks to optimize them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 cifar-10-batches-py/
 __pycache__
 .DS_Store
-
+*.params
+*-symbol.json

--- a/README.md
+++ b/README.md
@@ -156,7 +156,9 @@ The below offers some insights I gained after trying to match test-accuracy acro
    
 13. When using MXNet, you should avoid assigning outputs or data to numpy np.array in your training loop. This causes the data to be copied from the GPU to the CPU. You should use mx.nd.array instead, allocated in the right context at the beginning. This can dramatically increase performance.
 
-14. When using MXNet, operations are allocated on the queue of back-end engine and parallelized, try to avoid any blocking operations in your training loop. You can add a nd.waitall(), which will force waiting for all operations to complete at the end of each epoch to avoid filling up your memory.
+14. When using MXNet, operations are allocated on the queue of the back-end engine and parallelized, try to avoid any blocking operations in your training loop. You can add a nd.waitall(), which will force waiting for all operations to complete at the end of each epoch to avoid filling up your memory.
+
+15. With MXNet/Gluon, calling `.hybridize()` on your network will cache the computation graph and you will get performance gains. However that means that you won't be able to step through every calculations anymore. Use it once you are done debugging your network.
 
 #### RNN
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ The notebooks are executed on an Azure [Deep Learning Virtual Machine](https://a
 | [Caffe2](notebooks/Caffe2_CNN.ipynb)                  |        148         |         54          |
 | [Chainer](notebooks/Chainer_CNN.ipynb)                |        162         |         69          |
 | [CNTK](notebooks/CNTK_CNN.ipynb)                      |        163         |         53          |
-| [Gluon](notebooks/Gluon_CNN.ipynb)                    |        152         |         62          |
 | [Keras(CNTK)](notebooks/Keras_CNTK_CNN.ipynb)         |        194         |         76          |
 | [Keras(TF)](notebooks/Keras_TF_CNN.ipynb)             |        241         |         76          |
 | [Keras(Theano)](notebooks/Keras_Theano_CNN.ipynb)     |        269         |         93          |
 | [Tensorflow](notebooks/Tensorflow_CNN.ipynb)          |        173         |         57          |
 | [Lasagne(Theano)](notebooks/Theano_Lasagne_CNN.ipynb) |        253         |         65          |
-| [MXNet](notebooks/MXNet_CNN.ipynb)                    |        145         |         51          |
+| [MXNet(Gluon)](notebooks/Gluon_CNN.ipynb)             |        152         |         62          |
+| [MXNet(Module API)](notebooks/MXNet_CNN.ipynb)        |        145         |         51          |
 | [PyTorch](notebooks/PyTorch_CNN.ipynb)                |        169         |         51          |
 | [Julia - Knet](notebooks/Knet_CNN.ipynb)              |        159         |         ??          |
 | [R - MXNet](notebooks/.ipynb)                         |        ???         |         ??          |
@@ -50,9 +50,9 @@ Input for this model is the standard [CIFAR-10 dataset](http://www.cs.toronto.ed
 
 | DL Library                                        | 1xP100/CUDA 9/CuDNN 7 | 2xP100/CUDA 9/CuDNN 7 | 4xP100/CUDA 9/CuDNN 7 | 
 | -----------------------------------------------   | :------------------:  | :-------------------: | :------------------:  | 
-| [Pytorch](notebooks/PyTorch_MultiGPU.ipynb)       | 41min46s              | 28min50s              | 23min31s                     |
-| [Keras(TF)](notebooks/Keras_TF_MultiGPU.ipynb)    | 51min27s              | 32min1s               | 23min3s                     |
-| [Tensorflow](notebooks/Tensorflow_MultiGPU.ipynb) | 62min8s               | 44min13s              | 33min                     |
+| [Pytorch](notebooks/PyTorch_MultiGPU.ipynb)       | 41min46s              | 28min50s              | 23min31s              |
+| [Keras(TF)](notebooks/Keras_TF_MultiGPU.ipynb)    | 51min27s              | 32min1s               | 23min3s               |
+| [Tensorflow](notebooks/Tensorflow_MultiGPU.ipynb) | 62min8s               | 44min13s              | 33min                 |
 
 
 Input for this model is 112,120 PNGs of chest X-rays. **Note for the notebook to automatically download the data you must install [Azcopy](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-linux#download-and-install-azcopy) and increase the size of your OS-Disk in Azure Portal so that you have at-least 45GB of free-space (the Chest X-ray data is large!). The notebooks may take more than 10 minutes to first download the data.** These notebooks train DenseNet-121 and use native data-loaders to pre-process the data and perform data-augmentation. We want to rewrite the data-loaders to use OpenCV instead of PIL to reduce IO-bottlenecking.
@@ -67,7 +67,8 @@ Input for this model is 112,120 PNGs of chest X-rays. **Note for the notebook to
 | [Keras(CNTK)](notebooks/Keras_CNTK_Inference.ipynb) | 21.7               | 5.9                 |
 | [Keras(TF)](notebooks/Keras_TF_Inference.ipynb)     | 10.2               | 2.9                 |
 | [Tensorflow](notebooks/Tensorflow_Inference.ipynb)  | 6.5                | 1.8                 |
-| [MXNet](notebooks/MXNet_Inference.ipynb)            | 7.7                | 2.0                 |
+| [MXNet(Gluon)](notebooks/Gluon_Inference.ipynb)     | TBA                | TBA                 |
+| [MXNet(Module API)](notebooks/MXNet_Inference.ipynb)| 7.7                | 2.0                 |
 | [PyTorch](notebooks/PyTorch_Inference.ipynb)        | 7.7                | 1.9                 |
 | [Julia - Knet](notebooks/Knet_Inference.ipynb)      | 6.3                | ???                 |
 | [R - MXNet](notebooks/.ipynb)                       | ???                | ???                 |
@@ -82,7 +83,7 @@ A pre-trained ResNet50 model is loaded and chopped just after the avg_pooling at
 | [CNTK](notebooks/CNTK_RNN.ipynb)                   | 32                 | 15                  | Yes          |
 | [Keras(CNTK)](notebooks/Keras_CNTK_RNN.ipynb)      | 86                 | 53                  | No           |
 | [Keras(TF)](notebooks/Keras_TF_RNN.ipynb)          | 35                 | 26                  | Yes          |
-| [MXNet](notebooks/MXNet_RNN.ipynb)                 | 29                 | 24                  | Yes          |
+| [MXNet(Module API)](notebooks/MXNet_RNN.ipynb)     | 29                 | 24                  | Yes          |
 | [Pytorch](notebooks/PyTorch_RNN.ipynb)             | 31                 | 16                  | Yes          |
 | [Tensorflow](notebooks/Tensorflow_RNN.ipynb)       | 30                 | 22                  | Yes          |
 | [Julia - Knet](notebooks/Knet_RNN.ipynb)           | 29                 | ??                  | Yes          |
@@ -152,6 +153,10 @@ The below offers some insights I gained after trying to match test-accuracy acro
    make -j$(nproc)
    make install
    ```
+   
+13. When using MXNet, you should avoid assigning outputs or data to numpy np.array in your training loop. This causes the data to be copied from the GPU to the CPU. You should use mx.nd.array instead, allocated in the right context at the beginning. This can dramatically increase performance.
+
+14. When using MXNet, operations are allocated on the queue of back-end engine and parallelized, try to avoid any blocking operations in your training loop. You can add a nd.waitall(), which will force waiting for all operations to complete at the end of each epoch to avoid filling up your memory.
 
 #### RNN
 

--- a/notebooks/Gluon_CNN.ipynb
+++ b/notebooks/Gluon_CNN.ipynb
@@ -11,7 +11,20 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ec2-user/anaconda3/lib/python3.6/site-packages/urllib3/contrib/pyopenssl.py:46: DeprecationWarning: OpenSSL.rand is deprecated - you should use os.urandom instead\n",
+      "  import OpenSSL.SSL\n",
+      "/home/ec2-user/anaconda3/lib/python3.6/site-packages/matplotlib/__init__.py:962: UserWarning: Duplicate key in file \"/home/ec2-user/.config/matplotlib/matplotlibrc\", line #2\n",
+      "  (fname, cnt))\n",
+      "/home/ec2-user/anaconda3/lib/python3.6/site-packages/matplotlib/__init__.py:962: UserWarning: Duplicate key in file \"/home/ec2-user/.config/matplotlib/matplotlibrc\", line #3\n",
+      "  (fname, cnt))\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "import sys\n",
@@ -44,13 +57,13 @@
      "output_type": "stream",
      "text": [
       "OS:  linux\n",
-      "Python:  3.5.2 |Anaconda custom (64-bit)| (default, Jul  2 2016, 17:53:06) \n",
-      "[GCC 4.4.7 20120313 (Red Hat 4.4.7-1)]\n",
-      "MXNet:  0.12.0\n",
-      "Numpy:  1.14.1\n",
-      "GPU:  ['Tesla P100-PCIE-16GB', 'Tesla P100-PCIE-16GB']\n",
-      "CUDA Version 8.0.61\n",
-      "CuDNN Version  6.0.21\n"
+      "Python:  3.6.3 |Anaconda custom (64-bit)| (default, Oct 13 2017, 12:02:49) \n",
+      "[GCC 7.2.0]\n",
+      "MXNet:  1.1.0\n",
+      "Numpy:  1.13.3\n",
+      "GPU:  ['Tesla V100-SXM2-16GB']\n",
+      "CUDA Version 9.0.176\n",
+      "CuDNN Version  7.0.5\n"
      ]
     }
    ],
@@ -71,7 +84,7 @@
    "outputs": [],
    "source": [
     "def SymbolModule(n_classes=N_CLASSES):\n",
-    "    sym = gluon.nn.Sequential()\n",
+    "    sym = gluon.nn.HybridSequential()\n",
     "    with sym.name_scope():\n",
     "        sym.add(gluon.nn.Conv2D(channels=50, kernel_size=3, padding=1, activation='relu'))\n",
     "        sym.add(gluon.nn.Conv2D(channels=50, kernel_size=3, padding=1))\n",
@@ -121,8 +134,8 @@
       "Preparing test set...\n",
       "(50000, 3, 32, 32) (10000, 3, 32, 32) (50000,) (10000,)\n",
       "float32 float32 int32 int32\n",
-      "CPU times: user 630 ms, sys: 588 ms, total: 1.22 s\n",
-      "Wall time: 1.22 s\n"
+      "CPU times: user 940 ms, sys: 988 ms, total: 1.93 s\n",
+      "Wall time: 1.92 s\n"
      ]
     }
    ],
@@ -143,8 +156,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 321 ms, sys: 392 ms, total: 713 ms\n",
-      "Wall time: 876 ms\n"
+      "CPU times: user 744 ms, sys: 544 ms, total: 1.29 s\n",
+      "Wall time: 1.29 s\n"
      ]
     }
    ],
@@ -164,8 +177,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 203 µs, sys: 128 µs, total: 331 µs\n",
-      "Wall time: 337 µs\n"
+      "CPU times: user 0 ns, sys: 0 ns, total: 0 ns\n",
+      "Wall time: 552 µs\n"
      ]
     }
    ],
@@ -178,31 +191,50 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_loss = nd.zeros(1, ctx=ctx)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_loss += nd.ones(1, ctx=ctx)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch   0: loss: 1.8405\n",
-      "Epoch   1: loss: 1.3773\n",
-      "Epoch   2: loss: 1.1577\n",
-      "Epoch   3: loss: 0.9811\n",
-      "Epoch   4: loss: 0.8450\n",
-      "Epoch   5: loss: 0.7354\n",
-      "Epoch   6: loss: 0.6391\n",
-      "Epoch   7: loss: 0.5559\n",
-      "Epoch   8: loss: 0.4810\n",
-      "Epoch   9: loss: 0.4157\n",
-      "CPU times: user 1min 18s, sys: 15.3 s, total: 1min 34s\n",
-      "Wall time: 1min 2s\n"
+      "Epoch   0: loss: 1.8385\n",
+      "Epoch   1: loss: 1.3612\n",
+      "Epoch   2: loss: 1.1038\n",
+      "Epoch   3: loss: 0.9265\n",
+      "Epoch   4: loss: 0.7978\n",
+      "Epoch   5: loss: 0.6857\n",
+      "Epoch   6: loss: 0.5936\n",
+      "Epoch   7: loss: 0.5117\n",
+      "Epoch   8: loss: 0.4420\n",
+      "Epoch   9: loss: 0.3791\n",
+      "CPU times: user 50.8 s, sys: 14.5 s, total: 1min 5s\n",
+      "Wall time: 39.7 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
     "# Main training loop: 62s\n",
+    "sym.hybridize()\n",
     "for j in range(EPOCHS):\n",
-    "    train_loss = 0.0\n",
+    "    train_loss = nd.zeros(1, ctx=ctx)\n",
     "    for data, target in yield_mb(x_train, y_train, BATCHSIZE, shuffle=True):\n",
     "        # Get samples\n",
     "        data = nd.array(data).as_in_context(ctx)\n",
@@ -215,22 +247,24 @@
     "        # Back-prop\n",
     "        loss.backward()\n",
     "        trainer.step(data.shape[0])\n",
-    "        train_loss += nd.sum(loss).asscalar()\n",
-    "    # Log\n",
-    "    print('Epoch %3d: loss: %5.4f'%(j, train_loss/len(x_train)))"
+    "        train_loss += nd.sum(loss)\n",
+    "    # Log    \n",
+    "    # Waiting for the operations on the \n",
+    "    nd.waitall()\n",
+    "    print('Epoch %3d: loss: %5.4f'%(j, train_loss.asscalar()/len(x_train)))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 627 ms, sys: 73.1 ms, total: 700 ms\n",
-      "Wall time: 453 ms\n"
+      "CPU times: user 316 ms, sys: 80 ms, total: 396 ms\n",
+      "Wall time: 327 ms\n"
      ]
     }
    ],
@@ -254,14 +288,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy:  0.7661258012820513\n"
+      "Accuracy:  0.768429487179\n"
      ]
     }
    ],
@@ -287,7 +321,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/Gluon_CNN.ipynb
+++ b/notebooks/Gluon_CNN.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# High-level Gluon Example"
+    "# MXNet/Gluon CNN example"
    ]
   },
   {
@@ -134,8 +134,8 @@
       "Preparing test set...\n",
       "(50000, 3, 32, 32) (10000, 3, 32, 32) (50000,) (10000,)\n",
       "float32 float32 int32 int32\n",
-      "CPU times: user 940 ms, sys: 988 ms, total: 1.93 s\n",
-      "Wall time: 1.92 s\n"
+      "CPU times: user 856 ms, sys: 1.01 s, total: 1.87 s\n",
+      "Wall time: 1.86 s\n"
      ]
     }
    ],
@@ -156,8 +156,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 744 ms, sys: 544 ms, total: 1.29 s\n",
-      "Wall time: 1.29 s\n"
+      "CPU times: user 796 ms, sys: 480 ms, total: 1.28 s\n",
+      "Wall time: 1.27 s\n"
      ]
     }
    ],
@@ -177,8 +177,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 0 ns, sys: 0 ns, total: 0 ns\n",
-      "Wall time: 552 µs\n"
+      "CPU times: user 4 ms, sys: 0 ns, total: 4 ms\n",
+      "Wall time: 516 µs\n"
      ]
     }
    ],
@@ -214,24 +214,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch   0: loss: 1.8385\n",
-      "Epoch   1: loss: 1.3612\n",
-      "Epoch   2: loss: 1.1038\n",
-      "Epoch   3: loss: 0.9265\n",
-      "Epoch   4: loss: 0.7978\n",
-      "Epoch   5: loss: 0.6857\n",
-      "Epoch   6: loss: 0.5936\n",
-      "Epoch   7: loss: 0.5117\n",
-      "Epoch   8: loss: 0.4420\n",
-      "Epoch   9: loss: 0.3791\n",
-      "CPU times: user 50.8 s, sys: 14.5 s, total: 1min 5s\n",
-      "Wall time: 39.7 s\n"
+      "Epoch   0: loss: 1.8154\n",
+      "Epoch   1: loss: 1.3508\n",
+      "Epoch   2: loss: 1.1114\n",
+      "Epoch   3: loss: 0.9428\n",
+      "Epoch   4: loss: 0.8031\n",
+      "Epoch   5: loss: 0.7015\n",
+      "Epoch   6: loss: 0.6068\n",
+      "Epoch   7: loss: 0.5194\n",
+      "Epoch   8: loss: 0.4568\n",
+      "Epoch   9: loss: 0.4026\n",
+      "CPU times: user 51.5 s, sys: 14.4 s, total: 1min 5s\n",
+      "Wall time: 40 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "# Main training loop: 62s\n",
     "sym.hybridize()\n",
     "for j in range(EPOCHS):\n",
     "    train_loss = nd.zeros(1, ctx=ctx)\n",
@@ -249,22 +248,22 @@
     "        trainer.step(data.shape[0])\n",
     "        train_loss += nd.sum(loss)\n",
     "    # Log    \n",
-    "    # Waiting for the operations on the \n",
+    "    # Waiting for the operations on the     \n",
     "    nd.waitall()\n",
-    "    print('Epoch %3d: loss: %5.4f'%(j, train_loss.asscalar()/len(x_train)))"
+    "    print('Epoch %3d: loss: %5.4f'%(j, train_loss.asscalar()/len(x_train)))\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 316 ms, sys: 80 ms, total: 396 ms\n",
-      "Wall time: 327 ms\n"
+      "CPU times: user 312 ms, sys: 64 ms, total: 376 ms\n",
+      "Wall time: 314 ms\n"
      ]
     }
    ],
@@ -288,14 +287,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy:  0.768429487179\n"
+      "Accuracy:  0.763421474359\n"
      ]
     }
    ],

--- a/notebooks/Gluon_Inference.ipynb
+++ b/notebooks/Gluon_Inference.ipynb
@@ -1,8 +1,15 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MXNet/Gluon Inference"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -56,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -84,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -105,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,24 +124,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['bn1_moving_var', 'bn1_output', 'relu1_output', 'pool1_output', 'flatten0_output', 'fc1_weight', 'fc1_bias', 'fc1_output', 'softmax_label', 'softmax_output']\n"
+      "<Symbol group [bn1_moving_var, bn1, relu1, pool1, flatten0, fc1_weight, fc1_bias, fc1, softmax_label, softmax]>\n"
      ]
     }
    ],
    "source": [
-    "print(all_layers.list_outputs()[-10:])"
+    "print(all_layers[len(all_layers)-10:])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,78 +151,100 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We create the network\n",
+    "net = gluon.nn.SymbolBlock(outputs=flatten_layer, inputs=mx.sym.var('data'))\n",
+    "ctx = mx.gpu()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We assign the weights\n",
+    "net_params = net.collect_params()\n",
+    "for param in arg_params:\n",
+    "    if param in net_params:\n",
+    "        net_params[param]._load_init(arg_params[param], ctx=ctx)\n",
+    "for param in aux_params:\n",
+    "    if param in net_params:\n",
+    "        net_params[param]._load_init(aux_params[param], ctx=ctx)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We hybridize the network\n",
+    "net.hybridize()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
     "def predict_fn(classifier, data, batchsize):\n",
     "    \"\"\" Return features from classifier \"\"\"\n",
-    "    out = nd.zeros((len(data), RESNET_FEATURES), dtype=np.float32, ctx=ctx)    \n",
+    "    out = nd.zeros((len(data), RESNET_FEATURES), dtype=np.float32)\n",
     "    for idx, dta in yield_mb_X(data, batchsize):\n",
-    "        classifier.forward(Batch(data=[mx.nd.array(dta)]))\n",
-    "        out[idx*batchsize:(idx+1)*batchsize] = classifier.get_outputs()[0]\n",
+    "        outputs = classifier(mx.nd.array(dta, ctx=ctx))\n",
+    "        out[idx*batchsize:(idx+1)*batchsize] = outputs\n",
     "    nd.waitall()\n",
-    "    return out"
+    "    return out.asnumpy()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get last layer\n",
-    "fe_sym = all_layers['flatten0_output']\n",
-    "# Initialise GPU\n",
-    "fe_mod = mx.mod.Module(symbol=fe_sym, context=[mx.gpu(0)], label_names=None)\n",
-    "fe_mod.bind(for_training=False, inputs_need_grad=False,\n",
-    "            data_shapes=[('data', (BATCH_SIZE,3,224,224))])\n",
-    "fe_mod.set_params(arg_params, aux_params)"
+    "cold_start = predict_fn(net, fake_input_data_cf, BATCH_SIZE)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cold_start = predict_fn(fe_mod, fake_input_data_cf, BATCH_SIZE)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.43 s, sys: 500 ms, total: 1.93 s\n",
-      "Wall time: 1.27 s\n"
+      "CPU times: user 1.46 s, sys: 424 ms, total: 1.88 s\n",
+      "Wall time: 1.39 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "features = predict_fn(fe_mod, fake_input_data_cf, BATCH_SIZE)"
+    "features = predict_fn(net, fake_input_data_cf, BATCH_SIZE)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Images per second 1007.8740157480315\n"
+      "Images per second 920.8633093525181\n"
      ]
     }
    ],
    "source": [
-    "print(\"Images per second {}\".format((BATCH_SIZE*BATCHES_GPU)/1.27))"
+    "print(\"Images per second {}\".format((BATCH_SIZE*BATCHES_GPU)/1.39))"
    ]
   }
  ],

--- a/notebooks/MXNet_CNN.ipynb
+++ b/notebooks/MXNet_CNN.ipynb
@@ -286,9 +286,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
Following up from this discussion https://github.com/ilkarman/DeepLearningFrameworks/issues/55, updating to MXNet 1.1.0 and optimizing the code to avoid blocking the GPU for loss computation decrease the total run time by **25%**.

If you get the same gains on your setup that should bring the Gluon execution time to 46.5s on P100, maybe making it the fastest platform 😄 

The same problem was in the MXNet inference notebook, fixing it shaved **25%** inference time

I created a notebook for Gluon Inference and edited the README.md to use the MXNet(Gluon) and MXNet(Module API) terms for clarity.

I added two lessons learned to optimize MXNet training loops