### PR TITLE
Update to utils.py for Macs having CUDA installed

### DIFF
--- a/notebooks/common/utils.py
+++ b/notebooks/common/utils.py
@@ -36,7 +36,7 @@ def get_cuda_version():
     """Get CUDA version"""
     if sys.platform == 'win32':
         raise NotImplementedError("Implement this!")
-    elif sys.platform == 'linux':
+    elif sys.platform == 'linux' or sys.platform == 'darwin':
         path = '/usr/local/cuda/version.txt'
         if os.path.isfile(path):
             with open(path, 'r') as f:
@@ -44,8 +44,6 @@ def get_cuda_version():
             return data
         else:
             return "No CUDA in this machine"
-    elif sys.platform == 'darwin':
-        raise NotImplementedError("Find a Mac with GPU and implement this!")
     else:
         raise ValueError("Not in Windows, Linux or Mac")
 
@@ -78,7 +76,27 @@ def get_cudnn_version():
         else:
             return "No CUDNN in this machine"
     elif sys.platform == 'darwin':
-        raise NotImplementedError("Find a Mac with GPU and implement this!")
+        candidates = ['/usr/local/cuda/include/cudnn.h',
+                      '/usr/include/cudnn.h']
+        for c in candidates:
+            file = glob.glob(c)
+            if file: break
+        if file:
+            with open(file[0], 'r') as f:
+                version = ''
+                for line in f:
+                    if "#define CUDNN_MAJOR" in line:
+                        version = line.split()[-1]
+                    if "#define CUDNN_MINOR" in line:
+                        version += '.' + line.split()[-1]
+                    if "#define CUDNN_PATCHLEVEL" in line:
+                        version += '.' + line.split()[-1]
+            if version:
+                return version
+            else:
+                return "Cannot find CUDNN version"
+        else:
+            return "No CUDNN in this machine"
     else:
         raise ValueError("Not in Windows, Linux or Mac")
 


### PR DESCRIPTION
Added a few corrections to the utilities to find the cudnn and cuda version based on common locations for the setup on a Mac. For the get_gpu_name that may need something like pycuda or be able to get it after initializing the device.