### PR TITLE
Fix a bug in Chainer multi-GPUs notebook

### DIFF
--- a/notebooks/Chainer_MultiGPU.ipynb
+++ b/notebooks/Chainer_MultiGPU.ipynb
@@ -529,7 +529,7 @@
     "if MULTI_GPU:\n",
     "    train_iters = [\n",
     "        chainer.iterators.MultiprocessIterator(\n",
-    "            train_dataset, BATCHSIZE, n_prefetch=10, n_processes=int(CPU_COUNT/len(DEVICES))) \n",
+    "            i, BATCHSIZE, n_prefetch=10, n_processes=int(CPU_COUNT/len(DEVICES))) \n",
     "        for i in chainer.datasets.split_dataset_n_random(train_dataset, len(DEVICES))]\n",
     "else:\n",
     "    train_iter = chainer.iterators.MultiprocessIterator(\n",

--- a/notebooks/Chainer_MultiGPU.ipynb
+++ b/notebooks/Chainer_MultiGPU.ipynb
@@ -76,6 +76,7 @@
     "# Performance Improvement\n",
     "# 1. Auto-tune\n",
     "# This adds very little now .. not sure if True by default?\n",
+    "chainer.cuda.set_max_workspace_size(512 * 1024 * 1024)\n",
     "chainer.global_config.autotune = True"
    ]
   },


### PR DESCRIPTION
The current code creates a list of iterators which have the same dataset, so that the model sees a same data 4 times in a single epoch. This PR fixes the bug and adds a line to set the max workspace size to make "autotune" correctly work.

Could you kindly evaluate the speed again after merging this?